### PR TITLE
Fix tests for django 1.6 and 1.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     url='https://github.com/aptivate/django-sortable-listview',
     author='Sarah Bird',
     author_email='sarah@aptivate.org',
-    install_requires=['django>=1.4, <1.6'],
+    install_requires=['django>=1.4'],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Web Environment',

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -17,6 +17,18 @@ def runtests(*test_args):
     parent = os.path.dirname(os.path.abspath(__file__))
     sys.path.insert(0, parent)
 
+    # More setup is needed for Django >= 1.7
+    import django
+    settings.MIDDLEWARE_CLASSES = (
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.middleware.common.CommonMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
+    )
+    if hasattr(django, 'setup'):
+        django.setup()
+
     from django.test.simple import DjangoTestSuiteRunner
     failures = DjangoTestSuiteRunner(
         verbosity=1, interactive=True, failfast=False).run_tests(test_args)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -44,6 +44,7 @@ class TestGetContextData(TestCase):
         view = TestSortableListView()
         view.get_sort_string = MagicMock()
         view.sort_link_list = ['hola', 'mundo']
+        view.object_list = []
         context = view.get_context_data(object_list=[])
         self.assertEqual(context['sort_link_list'], ['hola', 'mundo'])
 
@@ -51,6 +52,7 @@ class TestGetContextData(TestCase):
         view = TestSortableListView()
         view.get_sort_string = MagicMock(return_value='sort=sortme')
         view.sort_link_list = []
+        view.object_list = []
         context = view.get_context_data(object_list=[])
         self.assertEqual(context['current_sort_query'], 'sort=sortme')
 
@@ -58,6 +60,7 @@ class TestGetContextData(TestCase):
         view = TestSortableListView()
         view.get_sort_string = MagicMock()
         view.sort_link_list = []
+        view.object_list = []
         view.get_context_data(object_list=[])
         view.get_sort_string.assert_called_once_with()
 


### PR DESCRIPTION
Hi!

* For django 1.6, I think we need to set ``object_list`` view attribute before calling ``get_context_data`` instead of passing it as a kwarg because of the evolution of ListView.get_context_data first line in django1.6 : 

    - queryset = kwargs.pop('object_list')
    + queryset = kwargs.pop('object_list', self.object_list)

* For django 1.7, we need to specify MIDDLEWARE_CLASSES and run django.setup()