### PR TITLE
Gives a way to smartly preserve query string

### DIFF
--- a/sortable_listview/templates/sortable_listview/pagination.html
+++ b/sortable_listview/templates/sortable_listview/pagination.html
@@ -1,28 +1,28 @@
 {% if is_paginated %}
   <ul class="pagination">
     {% if page_obj.has_previous %}
-      <li><a href="?page=1&amp;{{ current_sort_query }}">First</a></li>
-      <li><a href="?page={{ page_obj.previous_page_number }}&amp;{{ current_sort_query }}">Prev</a></li>
+      <li><a href="?page=1&amp;{{ current_sort_query }}&amp;{{ current_querystring }}">First</a></li>
+      <li><a href="?page={{ page_obj.previous_page_number }}&amp;{{ current_sort_query }}&amp;{{ current_querystring }}">Prev</a></li>
     {% else %}
       <li class="disabled"><span>First</span></li>
       <li class="disabled"><span>Prev</span></li>
     {% endif %}
     {% if not page_obj.has_next and page_obj.number >= 3 %}
-      <li><a href="?page={{ page_obj.number|add:"-2" }}&amp;{{ current_sort_query }}">{{ page_obj.number|add:"-2" }}</a></li>
+      <li><a href="?page={{ page_obj.number|add:"-2" }}&amp;{{ current_sort_query }}&amp;{{ current_querystring }}">{{ page_obj.number|add:"-2" }}</a></li>
     {% endif %}
     {% if page_obj.has_previous %}
-      <li><a href="?page={{ page_obj.previous_page_number }}&amp;{{ current_sort_query }}">{{ page_obj.previous_page_number }}</a></li>
+      <li><a href="?page={{ page_obj.previous_page_number }}&amp;{{ current_sort_query }}&amp;{{ current_querystring }}">{{ page_obj.previous_page_number }}</a></li>
     {% endif %}
       <li class="active"><a href="#">{{ page_obj.number }}</a></li>
     {% if page_obj.has_next %}
-      <li><a href="?page={{ page_obj.next_page_number }}&amp;{{ current_sort_query }}">{{ page_obj.next_page_number }}</a></li>
+      <li><a href="?page={{ page_obj.next_page_number }}&amp;{{ current_sort_query }}&amp;{{ current_querystring }}">{{ page_obj.next_page_number }}</a></li>
     {% endif %}
     {% if not page_obj.has_previous and page_obj.paginator.num_pages >= 3 %}
-      <li><a href="?page={{ page_obj.number|add:"2" }}&amp;{{ current_sort_query }}">{{ page_obj.number|add:"2" }}</a></li>
+      <li><a href="?page={{ page_obj.number|add:"2" }}&amp;{{ current_sort_query }}&amp;{{ current_querystring }}">{{ page_obj.number|add:"2" }}</a></li>
     {% endif %}
     {% if page_obj.has_next %}
-      <li><a href="?page={{ page_obj.next_page_number }}&amp;{{ current_sort_query }}">Next</a></li>
-      <li><a href="?page={{ page_obj.paginator.num_pages }}&amp;{{ current_sort_query }}">Last</a></li>
+      <li><a href="?page={{ page_obj.next_page_number }}&amp;{{ current_sort_query }}&amp;{{ current_querystring }}">Next</a></li>
+      <li><a href="?page={{ page_obj.paginator.num_pages }}&amp;{{ current_sort_query }}&amp;{{ current_querystring }}">Last</a></li>
     {% else %}
       <li class="disabled"><span>Next</span></li>
       <li class="disabled"><span>Last</span></li>


### PR DESCRIPTION
Hello,

After your (justified) comments on my precedent pull request which was breaking test (my bad obviously), I rewrite some things and refactor/add tests.

I use your app to sort / paginate search results. So I need to preserve the querystring (search criteria) while I change the sorting.

I hope this version will look better for you!

Florent
