### PR TITLE
Preserve ordering of allowed_sort_fields

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,16 @@
 import os
 from setuptools import setup
 
+install_requires = [
+    'django>=1.4',
+]
+
+try:
+    from collections import OrderedDict
+except ImportError:
+    # add backport to list of required modules
+    install_requires.append('ordereddict')
+
 README = open(os.path.join(os.path.dirname(__file__), 'README.md')).read()
 CHANGELOG = open(os.path.join(os.path.dirname(__file__), 'CHANGELOG.md')).read()
 LICENSE = open(os.path.join(os.path.dirname(__file__), 'LICENSE.txt')).read()
@@ -19,7 +29,7 @@ setup(
     url='https://github.com/aptivate/django-sortable-listview',
     author='Sarah Bird',
     author_email='sarah@aptivate.org',
-    install_requires=['django>=1.4'],
+    install_requires=install_requires,
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',


### PR DESCRIPTION
Hi,

I like your `SortableListView` but I missed one thing: The order of `allowed_sort_fields` is not preserved! This can be very useful when e.g. creating column based sorting in a table, because I don't have to hardcode the order in my template.
With my changes one can define the ordering in `allowed_sort_fields` when using e.g. a tuple of tuples similar to defining fieldsets in the django `ModelAdmin`:

``` python
default_sort_field = 'id'
allowed_sort_fields = (
    (default_sort_field, {'default_direction': '-', 'verbose_name': 'ID'}),
    ('vin', {'default_direction': '', 'verbose_name': 'VIN'}),
    ('sn', {'default_direction': '', 'verbose_name': _('Serial Number')}),
    ('customer', {'default_direction': '', 'verbose_name': _('Customer')}),
    ('customer__postal_code', {'default_direction': '', 'verbose_name': _('Postal Code')}),
)
```

For backwards compatibility the current `dict` approach works nevertheless.
