### PR TITLE
Python3 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-sortable-listview',
-    version='0.42',
+    version='0.43',
     packages=['sortable_listview'],
     include_package_data=True,
     license=LICENSE,

--- a/sortable_listview/views.py
+++ b/sortable_listview/views.py
@@ -98,7 +98,7 @@ class SortableListView(ListView):
         """
         to_remove = self.get_querystring_parameter_to_remove()
         query_string = urlparse(self.request.get_full_path()).query
-        query_dict = parse_qs(query_string.encode('utf-8'))
+        query_dict = parse_qs(query_string)
         for arg in to_remove:
             if arg in query_dict:
                 del query_dict[arg]


### PR DESCRIPTION
- Remove unicode('utf-8') from get_querystring
- pump version to 0.43
- fixes #16 